### PR TITLE
docs(readme): Update links and branding in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <a href="https://opencode.ai">
+  <a href="https://mammouth.ai">
     <picture>
       <source srcset="packages/console/app/src/asset/logotype.svg" media="(prefers-color-scheme: dark)">
       <img src="packages/console/app/src/asset/logotype.svg" alt="Mammouth AI logo">
@@ -8,7 +8,7 @@
 </p>
 <p align="center">Mammouth AI coding agent.</p>
 
-[![OpenCode Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://opencode.ai)
+[![Mammouth Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://info.mammouth.ai/fr/docs/mammouth-code/)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 <p align="center">Mammouth AI coding agent.</p>
 
-[![Mammouth Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://info.mammouth.ai/fr/docs/mammouth-code/)
+[![Mammouth Terminal UI](packages/web/src/assets/lander/screenshot.png)](https://info.mammouth.ai/docs/mammouth-code/)
 
 ---
 


### PR DESCRIPTION
This pull request updates the branding and documentation links in the `README.md` file to reflect the transition from OpenCode AI to Mammouth AI. The changes primarily focus on updating URLs and text references.

Branding updates:

* Changed the main logo link in the `README.md` from `https://opencode.ai` to `https://mammouth.ai` to reflect the new Mammouth AI branding.
* Updated the screenshot caption from "OpenCode Terminal UI" to "Mammouth Terminal UI" in the `README.md`.

Documentation link updates:

* Changed the screenshot link target from `https://opencode.ai` to `https://info.mammouth.ai/fr/docs/mammouth-code/` in the `README.md`.