### PR TITLE
Fix version check syntax in get_latest_version function

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -57,7 +57,7 @@ detect_platform() {
 
 # Get latest version from GitHub API
 get_latest_version() {
-  if [ -n "$VERSION" ]; then
+  if [ -n "${VERSION:-}" ]; then
     echo "$VERSION"
     return
   fi


### PR DESCRIPTION
### Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Though it's still not the case in the install script, this change allows using `set -euxo pipefail` instead of solely `set -e` like current setup, for debugging purposes.

### How did you verify your code works?

- Update the second line with `set -euxo pipefail` instead of `set -e`
- Run the script

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
